### PR TITLE
Add API URL env configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Exemplo de configuracao de ambiente para o frontend
+# URL base para as chamadas da API do backend
+NEXT_PUBLIC_API_URL=http://localhost:8080/api

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ yarn-error.log*
 
 # env files
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/api.md
+++ b/api.md
@@ -17,11 +17,17 @@ Esta documentação descreve os endpoints necessários para suportar o sistema d
 
 ## Base URL
 
+Defina a variável de ambiente `NEXT_PUBLIC_API_URL` para apontar para o backend desejado. Por exemplo:
+
+```bash
+# Ambiente local
+NEXT_PUBLIC_API_URL=http://localhost:8080/api
+
+# Produção
+NEXT_PUBLIC_API_URL=https://api.unyxticket.com/v1
+
 ```
 
-[https://api.unyxticket.com/v1](https://api.unyxticket.com/v1)
-
-```plaintext
 
 ## Autenticação
 

--- a/contexts/auth-context.tsx
+++ b/contexts/auth-context.tsx
@@ -42,10 +42,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setIsLoading(false)
   }, [])
 
+  const API_URL = process.env.NEXT_PUBLIC_API_URL || "https://unyxticket.site/api"
+
   const login = async (email: string, password: string) => {
     try {
       setIsLoading(true)
-      const response = await fetch("https://unyxticket.site/api/auth/login", {
+      const response = await fetch(`${API_URL}/auth/login`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -85,7 +87,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const register = async (email: string, password: string) => {
     try {
       setIsLoading(true)
-      const response = await fetch("https://unyxticket.site/api/auth/register", {
+      const response = await fetch(`${API_URL}/auth/register`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
- allow `.env.example` to be tracked
- fetch API URL from `NEXT_PUBLIC_API_URL`
- document environment configuration

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm build` *(fails to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68506d2bf3848320897843e2f0f5fec3